### PR TITLE
Multiple areas in API

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir --upgrade \
     uvicorn \
     joblib==1.2.0 \
     pandas==1.5.3 \
-    libpysal==4.7.0 \
+    libpysal==4.9.2 \
     xarray==2023.1.0 \
     pyarrow==11.0.0 \
     scikit-learn==1.2.0 \

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,19 +1,15 @@
-FROM python:3.11
+FROM mambaorg/micromamba:1.5.5
+COPY --chown=$MAMBA_USER:$MAMBA_USER env.yaml /tmp/env.yaml
+RUN micromamba install -y -n base -f /tmp/env.yaml && \
+    micromamba clean --all --yes
+
+LABEL org.opencontainers.image.source=https://github.com/Urban-Analytics-Technology-Platform/demoland-engine
+LABEL org.opencontainers.image.description="Container used to deploy Demoland API"
+LABEL org.opencontainers.image.licenses=MIT
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 WORKDIR /code
-
-RUN pip install --no-cache-dir --upgrade \
-    fastapi \
-    pydantic \
-    uvicorn \
-    joblib==1.2.0 \
-    pandas==1.5.3 \
-    libpysal==4.9.2 \
-    xarray==2023.1.0 \
-    pyarrow==11.0.0 \
-    scikit-learn==1.2.0 \
-    setuptools_scm \
-    pooch
 
 COPY ./demoland_engine /code/demoland_engine
 COPY ./pyproject.toml /code/pyproject.toml

--- a/api/main.py
+++ b/api/main.py
@@ -50,13 +50,10 @@ async def root_POST(
 
     See the `docker_usage.ipynb` notebook for example Python usage.
     """
-    print("Received request with model_identifier: ", body.model_identifier)
-
     # Set the environment variable before importing to avoid loading default
     # Tyne and Wear data every time this endpoint is called.
     os.environ["DEMOLAND"] = body.model_identifier
     import demoland_engine
-    print(demoland_engine.__file__)
 
     scenario = body.scenario_json
     demoland_engine.data.change_area(body.model_identifier)

--- a/api/main.py
+++ b/api/main.py
@@ -1,10 +1,8 @@
 import os
+from dataclasses import dataclass
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-
-import demoland_engine
 
 app = FastAPI()
 
@@ -22,9 +20,15 @@ app.add_middleware(
     ),
 )
 
-
-class ScenarioJSON(BaseModel):
+@dataclass
+class ScenarioRequest:
+    """
+    A dataclass is used here instead of Pydantic's BaseModel because BaseModel
+    reserves attributes beginning with `model_` for internal use. See
+    https://github.com/pydantic/pydantic/issues/4915
+    """
     scenario_json: dict
+    model_identifier: str = "tyne_and_wear"
 
 
 @app.get("/")
@@ -38,7 +42,7 @@ async def root_GET():
 
 @app.post("/")
 async def root_POST(
-    scenario_json: ScenarioJSON,
+    body: ScenarioRequest,
 ):
     """
     Returns a JSON object with the predicted indicator values and signature
@@ -46,21 +50,23 @@ async def root_POST(
 
     See the `docker_usage.ipynb` notebook for example Python usage.
     """
+    print("Received request with model_identifier: ", body.model_identifier)
 
-    scenario_data = scenario_json.scenario_json
+    # Set the environment variable before importing to avoid loading default
+    # Tyne and Wear data every time this endpoint is called.
+    os.environ["DEMOLAND"] = body.model_identifier
+    import demoland_engine
+    print(demoland_engine.__file__)
 
-    demoland_engine.data.change_area(
-        scenario_data.get("model_identifier", "tyne_and_wear")
-    )
-
-    scenario = scenario_data["scenario_json"]
+    scenario = body.scenario_json
+    demoland_engine.data.change_area(body.model_identifier)
 
     df = demoland_engine.get_empty()
     for oa_code, vals in scenario.items():
         df.loc[oa_code] = list(vals.values())
 
     pred = demoland_engine.get_indicators(df, random_seed=42)
-    sig = demoland_engine.sampling.oa_key.primary_type.copy()
+    sig = demoland_engine.data.FILEVAULT["oa_key"].primary_type.copy()
 
     mapping = {
         "Wild countryside": 0,
@@ -84,5 +90,6 @@ async def root_POST(
     changed = df.signature_type[df.signature_type.notna()]
     sig.loc[changed.index] = changed
     pred["signature_type"] = sig
+    pred = pred.dropna(subset=["signature_type"])
 
     return pred.to_dict("index")

--- a/demoland_engine/predictors.py
+++ b/demoland_engine/predictors.py
@@ -4,14 +4,6 @@ from .sampling import get_data
 from .data import CACHE, FILEVAULT
 from .indicators import Model
 
-matrix = FILEVAULT["matrix"]
-aq_model = FILEVAULT["aq_model"]
-hp_model = FILEVAULT["hp_model"]
-accessibility = FILEVAULT["accessibility"]
-
-air_quality_predictor = Model(matrix, aq_model)
-house_price_predictor = Model(matrix, hp_model)
-
 
 def get_indicators(df, mode="walk", random_seed=None):
     """Get indicators for all OAs based on 4 variables
@@ -71,6 +63,14 @@ def get_indicators(df, mode="walk", random_seed=None):
     DataFrame
         DataFrame containing the resulting indicators
     """
+    matrix = FILEVAULT["matrix"]
+    aq_model = FILEVAULT["aq_model"]
+    hp_model = FILEVAULT["hp_model"]
+    accessibility = FILEVAULT["accessibility"]
+
+    air_quality_predictor = Model(matrix, aq_model)
+    house_price_predictor = Model(matrix, hp_model)
+
     vars, jobs, gsp = get_data(df, random_seed=random_seed)
     aq = air_quality_predictor.predict(vars)
     hp = house_price_predictor.predict(vars)

--- a/demoland_engine/sampling.py
+++ b/demoland_engine/sampling.py
@@ -3,14 +3,6 @@ import pandas as pd
 
 from .data import FILEVAULT
 
-median_form = FILEVAULT["median_form"]
-iqr_form = FILEVAULT["iqr_form"]
-median_function = FILEVAULT["median_function"]
-iqr_function = FILEVAULT["iqr_function"]
-oa_key = FILEVAULT["oa_key"]
-oa_area = FILEVAULT["oa_area"].area
-default_data = FILEVAULT["default_data"]
-
 
 SIGS = {
     0: "Wild countryside",
@@ -39,6 +31,9 @@ def _form(signature_type, variable, random_seed):
     median of a variable per signature type. The spread is
     defined as 1/5 of interquartile range.
     """
+    median_form = FILEVAULT["median_form"]
+    iqr_form = FILEVAULT["iqr_form"]
+
     rng = np.random.default_rng(random_seed)
     return rng.normal(
         median_form.loc[signature_type, variable],
@@ -53,6 +48,9 @@ def _function(signature_type, variable, random_seed):
     median of a variable per signature type. The spread is
     defined as 1/5 of interquartile range.
     """
+    median_function = FILEVAULT["median_function"]
+    iqr_function = FILEVAULT["iqr_function"]
+
     rng = np.random.default_rng(random_seed)
     return rng.normal(
         median_function.loc[signature_type, variable],
@@ -214,6 +212,11 @@ def get_signature_values(
     -------
     Series
     """
+    median_form = FILEVAULT["median_form"]
+    median_function = FILEVAULT["median_function"]
+    oa_key = FILEVAULT["oa_key"]
+    oa_area = FILEVAULT["oa_area"].area
+
     if signature_type is not None:
         signature_type = SIGS[signature_type]
     orig_type = oa_key.primary_type[oa_code]
@@ -346,6 +349,8 @@ def get_signature_values(
 
 
 def get_data(df, random_seed=None):
+    default_data = FILEVAULT["default_data"]
+
     # get the default
     exvars = default_data.copy()
     jobs_diff = pd.Series(0, index=df.index.values, dtype=float, name="oa")

--- a/env.yaml
+++ b/env.yaml
@@ -14,8 +14,13 @@ dependencies:
   - pyogrio=0.7.2
   - r5py=0.1.1
   - requests=2.31.0
-  - scikit-learn=1.3.2
+  - scikit-learn=1.3.1
   - xarray
+  - fastapi
+  - pydantic
+  - uvicorn
+  - setuptools_scm
+  - pooch
   - git
   - pip
   - pip:


### PR DESCRIPTION
Modifications to the API to generalise it to any area.

Will comment on individual lines of code in the PR

There are a couple of remaining problems which I can't fix on my end

# (1) sklearn version inconsistency

The process of switching the files in and out seems to be working perfectly (as far as I can tell), however, the models for `tyne_and_wear` and `tyne_and_wear_hex` seem to be serialised with a different version of sklearn (1.2.0 and 1.3.2 respectively) and are not compatible with one another.

So, if I pin `scikit-learn==1.2.0` in the `pyproject.toml` then the prediction fails for `tyne_and_wear_hex`:

```
  File "/Users/jyong/demoland/engine/api/main.py", line 68, in root_POST
    pred = demoland_engine.get_indicators(df, random_seed=42)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/demoland_engine/predictors.py", line 75, in get_indicators
    aq = air_quality_predictor.predict(vars)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/demoland_engine/indicators.py", line 22, in predict
    return self.model.predict(data[self.model.feature_names_in_])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py", line 1487, in predict
    return self._loss.link.inverse(self._raw_predict(X).ravel())
                                   ^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py", line 1043, in _raw_predict
    self._predict_iterations(
  File "/opt/homebrew/lib/python3.11/site-packages/sklearn/ensemble/_hist_gradient_boosting/gradient_boosting.py", line 1071, in _predict_iterations
    raw_predictions[:, k] += predict(X)
                             ^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/sklearn/ensemble/_hist_gradient_boosting/predictor.py", line 69, in predict
    _predict_from_raw_data(
  File "sklearn/ensemble/_hist_gradient_boosting/_predictor.pyx", line 17, in sklearn.ensemble._hist_gradient_boosting._predictor._predict_from_raw_data
ValueError: Buffer dtype mismatch, expected 'unsigned int' but got 'long long' in 'node_struct.feature_idx'
```

We can't change the version of sklearn on the fly so we should choose one version and stick to it (for good).

The choice will probably depend on the version of sklearn that is available in pyodide. In particular, we are using pyodide==0.24.1 right now which is [compatible *only* with scikit-learn==1.3.1](https://pyodide.org/en/stable/project/changelog.html#version-0-24-1).


# (2) Docker image can't be built

This is less urgent since the Azure deployment no longer uses Docker, but since there is a Dockerfile (and a docker_usage notebook) we should probably make it work. The issue stems from `libpysal==4.9.2` now having geopandas as a dependency.

I could probably figure out how to fix this myself, but I'm guessing you probably already know the fix 😅 

```
$ docker build -f Dockerfile.api -t demoland_api .
[...]
#6 8.230 Collecting fiona>=1.8.21 (from geopandas>=0.10.0->libpysal==4.9.2)
#6 8.242   Downloading fiona-1.9.5.tar.gz (409 kB)
#6 8.278      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 409.3/409.3 kB 11.6 MB/s eta 0:00:00
#6 8.307   Installing build dependencies: started
#6 12.81   Installing build dependencies: finished with status 'done'
#6 12.81   Getting requirements to build wheel: started
#6 12.92   Getting requirements to build wheel: finished with status 'error'
#6 12.92   error: subprocess-exited-with-error
#6 12.92
#6 12.92   × Getting requirements to build wheel did not run successfully.
#6 12.92   │ exit code: 1
#6 12.92   ╰─> [3 lines of output]
#6 12.92       <string>:86: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
#6 12.92       WARNING:root:Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'
#6 12.92       CRITICAL:root:A GDAL API version must be specified. Provide a path to gdal-config using a GDAL_CONFIG environment variable or use a GDAL_VERSION environment variable.
#6 12.92       [end of output]
```